### PR TITLE
AB#227: Downgrade Allure version to available support version of Azuze DevOps.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <log4j2.version>2.17.1</log4j2.version>
         <slf4j.version>2.0.3</slf4j.version>
         <aspectj.version>1.8.13</aspectj.version>
-        <allure-testng-version>1.5.4</allure-testng-version>
+        <allure-testng-version>1.4.24.RC3</allure-testng-version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Test local results:
![image](https://user-images.githubusercontent.com/76104139/210293165-615bba90-1c0c-4883-ae7b-9be9a125c9ec.png)

New changes:
1/ Downgrade Allure version from 1.5.4 to 1.4.24.RC3