### PR TITLE
AB#227: Downgrade Allure version to available support version of Azure DevOps.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <log4j2.version>2.17.1</log4j2.version>
         <slf4j.version>2.0.3</slf4j.version>
         <aspectj.version>1.8.13</aspectj.version>
-        <allure-testng-version>1.4.24.RC3</allure-testng-version>
+        <allure-testng-version>1.4.23</allure-testng-version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Test local results:
![image](https://user-images.githubusercontent.com/76104139/210308444-6a33482d-48be-400a-9c2e-870e243b0084.png)

New changes:
1/ Downgrade Allure version from 1.4.24.RC3 to 1.4.23